### PR TITLE
Fyhenry sql migration

### DIFF
--- a/.vscode/inote-rest-api.code-workspace
+++ b/.vscode/inote-rest-api.code-workspace
@@ -16,7 +16,7 @@
 				"previewLimit": 50,
 				"server": "127.0.0.1",
 				"port": 3306,
-				"driver": "MySQL",
+				"driver": "MariaDB",
 				"name": "inote",
 				"database": "inote",
 				"username": "moch",
@@ -73,5 +73,5 @@
 			// Javadoc Generation
 			"madhavd1.javadoc-tools"
 		]
-	},
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.5</version>
+        <version>3.2.6</version>
         <relativePath />
     </parent>
 
@@ -102,11 +102,11 @@
             <scope>runtime</scope>
             <optional>true</optional>
         </dependency>
-
-        <!-- MySQL driver -->
+        
+        <!-- MariaDB driver -->
         <dependency>
-            <groupId>com.mysql</groupId>
-            <artifactId>mysql-connector-j</artifactId>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,7 +6,7 @@ spring.config.import=optional:file:./../.env[.properties]
 #============================================
     # Datasource configuration
     spring.datasource.url=${SDS_URL}
-    spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+    spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
     spring.datasource.username=${SDS_USER}
     spring.datasource.password=${SDS_PW}
 


### PR DESCRIPTION
# Transition de MySQL à MariaDB

Un nouveau connecteur est installé pour correspondre à MariaDB sans ambiguïté.

Un *patch* est ajouté pour Spring Boot pour mettre à jour la sécurité.

L’espace de travail est renommé `INOTE-REST-API`.